### PR TITLE
[improve][ml] Use lock-free queues in InflightReadsLimiter.java to improve performance

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -802,33 +802,41 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         buffer.retain();
 
         // Jump to specific thread to avoid contention from writers writing from different threads
-        executor.execute(() -> {
-            OpAddEntry addOperation = OpAddEntry.createNoRetainBuffer(this, buffer, numberOfMessages, callback, ctx,
-                    currentLedgerTimeoutTriggered);
-            internalAsyncAddEntry(addOperation);
-        });
+        final var addOperation = OpAddEntry.createNoRetainBuffer(this, buffer, numberOfMessages, callback, ctx,
+                currentLedgerTimeoutTriggered);
+        var added = false;
+        try {
+            // Use synchronized to ensure if `addOperation` is added to queue and fails later, it will be the first
+            // element in `pendingAddEntries`.
+            synchronized (this) {
+                if (managedLedgerInterceptor != null) {
+                    managedLedgerInterceptor.beforeAddEntry(addOperation, addOperation.getNumberOfMessages());
+                }
+                final var state = STATE_UPDATER.get(this);
+                beforeAddEntryToQueue(state);
+                pendingAddEntries.add(addOperation);
+                added = true;
+                afterAddEntryToQueue(state, addOperation);
+            }
+        } catch (Throwable throwable) {
+            if (!added) {
+                addOperation.failed(ManagedLedgerException.getManagedLedgerException(throwable));
+            } // else: all elements of `pendingAddEntries` will fail in another thread
+        }
     }
 
-    protected synchronized void internalAsyncAddEntry(OpAddEntry addOperation) {
-        if (!beforeAddEntry(addOperation)) {
-            return;
-        }
-        final State state = STATE_UPDATER.get(this);
+    protected void beforeAddEntryToQueue(State state) throws ManagedLedgerException {
         if (state.isFenced()) {
-            addOperation.failed(new ManagedLedgerFencedException());
-            return;
-        } else if (state == State.Terminated) {
-            addOperation.failed(new ManagedLedgerTerminatedException("Managed ledger was already terminated"));
-            return;
-        } else if (state == State.Closed) {
-            addOperation.failed(new ManagedLedgerAlreadyClosedException("Managed ledger was already closed"));
-            return;
-        } else if (state == State.WriteFailed) {
-            addOperation.failed(new ManagedLedgerAlreadyClosedException("Waiting to recover from failure"));
-            return;
+            throw new ManagedLedgerFencedException();
         }
-        pendingAddEntries.add(addOperation);
+        switch (state) {
+            case Terminated -> throw new ManagedLedgerTerminatedException("Managed ledger was already terminated");
+            case Closed -> throw new ManagedLedgerAlreadyClosedException("Managed ledger was already closed");
+            case WriteFailed -> throw new ManagedLedgerAlreadyClosedException("Waiting to recover from failure");
+        }
+    }
 
+    protected void afterAddEntryToQueue(State state, OpAddEntry addOperation) throws ManagedLedgerException {
         if (state == State.ClosingLedger || state == State.CreatingLedger) {
             // We don't have a ready ledger to write into
             // We are waiting for a new ledger to be created

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1152,16 +1152,17 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return cachedCursor;
         }
 
-        NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, this, cursorName,
-                startCursorPosition, initialPosition, isReadCompacted);
-        cursor.setActive();
-
-        log.info("[{}] Opened new cursor: {}", name, cursor);
+        // The backlog of a non-durable cursor could be incorrect if the cursor is created before `internalTrimLedgers`
+        // and added to the managed ledger after `internalTrimLedgers`.
+        // For more details, see https://github.com/apache/pulsar/pull/23951.
         synchronized (this) {
+            NonDurableCursorImpl cursor = new NonDurableCursorImpl(bookKeeper, this, cursorName,
+                    startCursorPosition, initialPosition, isReadCompacted);
+            cursor.setActive();
+            log.info("[{}] Opened new cursor: {}", name, cursor);
             addCursor(cursor);
+            return cursor;
         }
-
-        return cursor;
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ShadowManagedLedgerImpl.java
@@ -223,25 +223,23 @@ public class ShadowManagedLedgerImpl extends ManagedLedgerImpl {
     }
 
     @Override
-    protected synchronized void internalAsyncAddEntry(OpAddEntry addOperation) {
-        if (!beforeAddEntry(addOperation)) {
-            return;
-        }
+    protected void beforeAddEntryToQueue(State state) throws ManagedLedgerException {
         if (state != State.LedgerOpened) {
-            addOperation.failed(new ManagedLedgerException("Managed ledger is not opened"));
-            return;
+            throw new ManagedLedgerException("Managed ledger is not opened");
         }
+    }
 
+    @Override
+    protected void afterAddEntryToQueue(State state, OpAddEntry addOperation) throws ManagedLedgerException {
         if (addOperation.getCtx() == null || !(addOperation.getCtx() instanceof Position position)) {
-            addOperation.failed(new ManagedLedgerException("Illegal addOperation context object."));
-            return;
+            pendingAddEntries.poll();
+            throw new ManagedLedgerException("Illegal addOperation context object.");
         }
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Add entry into shadow ledger lh={} entries={}, pos=({},{})",
                     name, currentLedger.getId(), currentLedgerEntries, position.getLedgerId(), position.getEntryId());
         }
-        pendingAddEntries.add(addOperation);
         if (position.getLedgerId() <= currentLedger.getId()) {
             // Write into lastLedger
             if (position.getLedgerId() == currentLedger.getId()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.opentelemetry.Constants;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.InflightReadLimiterUtilization;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
-import org.jctools.queues.SpscArrayQueue;
 
 @Slf4j
 public class InflightReadsLimiter implements AutoCloseable {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -180,7 +180,7 @@ public class InflightReadsLimiter implements AutoCloseable {
                 log.warn("Failed to queue handle for acquiring permits: {}, creationTime: {}, remainingBytes:{}",
                         permits, handle.creationTime, remainingBytes);
                 return Optional.of(new Handle(0, handle.creationTime, false));
-            }else {
+            } else {
                 queuedHandles.offer(new QueuedHandle(handle, callback));
                 scheduleTimeOutCheck(acquireTimeoutMillis);
                 return Optional.empty();

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -86,7 +86,7 @@ public class InflightReadsLimiter implements AutoCloseable {
         this.maxReadsInFlightAcquireQueueSize = maxReadsInFlightAcquireQueueSize;
         if (maxReadsInFlightSize > 0) {
             enabled = true;
-            this.queuedHandles = new ArrayDeque<>(maxReadsInFlightAcquireQueueSize);
+            this.queuedHandles = new ArrayDeque<>();
         } else {
             enabled = false;
             this.queuedHandles = null;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/cache/InflightReadsLimiter.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.prometheus.client.Gauge;
+import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -31,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.opentelemetry.Constants;
 import org.apache.pulsar.opentelemetry.OpenTelemetryAttributes.InflightReadLimiterUtilization;
 import org.apache.pulsar.opentelemetry.annotations.PulsarDeprecatedMetric;
-import org.jctools.queues.SpscArrayQueue;
 
 @Slf4j
 public class InflightReadsLimiter implements AutoCloseable {
@@ -84,7 +84,7 @@ public class InflightReadsLimiter implements AutoCloseable {
         this.timeOutExecutor = timeOutExecutor;
         if (maxReadsInFlightSize > 0) {
             enabled = true;
-            this.queuedHandles = new SpscArrayQueue<>(maxReadsInFlightAcquireQueueSize);
+            this.queuedHandles = new ArrayDeque<>(maxReadsInFlightAcquireQueueSize);
         } else {
             enabled = false;
             this.queuedHandles = null;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/RangeCache.java
@@ -284,6 +284,9 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
         }
     }
 
+    /**
+     * @apiNote the returned value must be released if it's not null
+     */
     private Value getValueMatchingEntry(Map.Entry<Key, EntryWrapper<Key, Value>> entry) {
         Value valueMatchingEntry = EntryWrapper.getValueMatchingMapEntry(entry);
         return getRetainedValueMatchingKey(entry.getKey(), valueMatchingEntry);
@@ -291,6 +294,9 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
 
     // validates that the value matches the key and that the value has not been recycled
     // which are possible due to the lack of exclusive locks in the cache and the use of reference counted objects
+    /**
+     * @apiNote the returned value must be released if it's not null
+     */
     private Value getRetainedValueMatchingKey(Key key, Value value) {
         if (value == null) {
             // the wrapper has been recycled and contains another key
@@ -350,7 +356,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
         RemovalCounters counters = RemovalCounters.create();
         Map<Key, EntryWrapper<Key, Value>> subMap = entries.subMap(first, true, last, lastInclusive);
         for (Map.Entry<Key, EntryWrapper<Key, Value>> entry : subMap.entrySet()) {
-            removeEntry(entry, counters, true);
+            removeEntry(entry, counters);
         }
         return handleRemovalResult(counters);
     }
@@ -361,84 +367,48 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
         BREAK_LOOP;
     }
 
-    private RemoveEntryResult removeEntry(Map.Entry<Key, EntryWrapper<Key, Value>> entry, RemovalCounters counters,
-                                          boolean skipInvalid) {
-        return removeEntry(entry, counters, skipInvalid, x -> true);
+    private RemoveEntryResult removeEntry(Map.Entry<Key, EntryWrapper<Key, Value>> entry, RemovalCounters counters) {
+        return removeEntry(entry, counters, x -> true);
     }
 
     private RemoveEntryResult removeEntry(Map.Entry<Key, EntryWrapper<Key, Value>> entry, RemovalCounters counters,
-                                          boolean skipInvalid, Predicate<Value> removeCondition) {
+                                          Predicate<Value> removeCondition) {
         Key key = entry.getKey();
         EntryWrapper<Key, Value> entryWrapper = entry.getValue();
         Value value = getValueMatchingEntry(entry);
         if (value == null) {
-            // the wrapper has already been recycled and contains another key
-            if (!skipInvalid) {
-                EntryWrapper<Key, Value> removed = entries.remove(key);
-                if (removed != null) {
-                    // log and remove the entry without releasing the value
-                    log.info("Key {} does not match the entry's value wrapper's key {}, removed entry by key without "
-                            + "releasing the value", key, entryWrapper.getKey());
-                    counters.entryRemoved(removed.getSize());
-                    return RemoveEntryResult.ENTRY_REMOVED;
-                }
-            }
+            // the wrapper has already been recycled or contains another key
+            entries.remove(key, entryWrapper);
             return RemoveEntryResult.CONTINUE_LOOP;
-        }
-        try {
-            // add extra retain to avoid value being released while we are removing it
-            value.retain();
-        } catch (IllegalReferenceCountException e) {
-            // Value was already released
-            if (!skipInvalid) {
-                // remove the specific entry without releasing the value
-                if (entries.remove(key, entryWrapper)) {
-                    log.info("Value was already released for key {}, removed entry without releasing the value", key);
-                    counters.entryRemoved(entryWrapper.getSize());
-                    return RemoveEntryResult.ENTRY_REMOVED;
-                }
-            }
-            return RemoveEntryResult.CONTINUE_LOOP;
-        }
-        if (!value.matchesKey(key)) {
-            // this is unexpected since the IdentityWrapper.getValue(key) already checked that the value matches the key
-            log.warn("Unexpected race condition. Value {} does not match the key {}. Removing entry.", value, key);
         }
         try {
             if (!removeCondition.test(value)) {
                 return RemoveEntryResult.BREAK_LOOP;
             }
-            if (!skipInvalid) {
-                // remove the specific entry
-                boolean entryRemoved = entries.remove(key, entryWrapper);
-                if (entryRemoved) {
-                    counters.entryRemoved(entryWrapper.getSize());
-                    // check that the value hasn't been recycled in between
-                    // there should be at least 2 references since this method adds one and the cache should have
-                    // one reference. it is valid that the value contains references even after the key has been
-                    // removed from the cache
-                    if (value.refCnt() > 1) {
-                        entryWrapper.recycle();
-                        // remove the cache reference
-                        value.release();
-                    } else {
-                        log.info("Unexpected refCnt {} for key {}, removed entry without releasing the value",
-                                value.refCnt(), key);
-                    }
-                }
-            } else if (skipInvalid && value.refCnt() > 1 && entries.remove(key, entryWrapper)) {
-                // when skipInvalid is true, we don't remove the entry if it doesn't match matches the key
-                // or the refCnt is invalid
+            // remove the specific entry
+            boolean entryRemoved = entries.remove(key, entryWrapper);
+            if (entryRemoved) {
                 counters.entryRemoved(entryWrapper.getSize());
-                entryWrapper.recycle();
-                // remove the cache reference
-                value.release();
+                // check that the value hasn't been recycled in between
+                // there should be at least 2 references since this method adds one and the cache should have
+                // one reference. it is valid that the value contains references even after the key has been
+                // removed from the cache
+                if (value.refCnt() > 1) {
+                    entryWrapper.recycle();
+                    // remove the cache reference
+                    value.release();
+                } else {
+                    log.info("Unexpected refCnt {} for key {}, removed entry without releasing the value",
+                            value.refCnt(), key);
+                }
+                return RemoveEntryResult.ENTRY_REMOVED;
+            } else {
+                return RemoveEntryResult.CONTINUE_LOOP;
             }
         } finally {
             // remove the extra retain
             value.release();
         }
-        return RemoveEntryResult.ENTRY_REMOVED;
     }
 
     private Pair<Integer, Long> handleRemovalResult(RemovalCounters counters) {
@@ -464,7 +434,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
             if (entry == null) {
                 break;
             }
-            removeEntry(entry, counters, false);
+            removeEntry(entry, counters);
         }
         return handleRemovalResult(counters);
     }
@@ -484,7 +454,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
            if (entry == null) {
                break;
            }
-           if (removeEntry(entry, counters, false, value -> timestampExtractor.getTimestamp(value) <= maxTimestamp)
+           if (removeEntry(entry, counters, value -> timestampExtractor.getTimestamp(value) <= maxTimestamp)
                    == RemoveEntryResult.BREAK_LOOP) {
                break;
            }
@@ -518,7 +488,7 @@ public class RangeCache<Key extends Comparable<Key>, Value extends ValueWithKeyV
             if (entry == null) {
                 break;
             }
-            removeEntry(entry, counters, false);
+            removeEntry(entry, counters);
         }
         return handleRemovalResult(counters);
     }

--- a/microbench/README.md
+++ b/microbench/README.md
@@ -41,3 +41,29 @@ For fast recompiling of the benchmarks (without compiling Pulsar modules) and cr
 mvn -Pmicrobench -pl microbench clean package
 ```
 
+### Running specific benchmarks
+
+Display help:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar -h
+```
+
+Listing all benchmarks:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar -l
+```
+
+Running specific benchmarks:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar ".*BenchmarkName.*"
+```
+
+Checking what benchmarks match the pattern:
+
+```shell
+java -jar microbench/target/microbenchmarks.jar ".*BenchmarkName.*" -lp
+```
+

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ flexible messaging model and an intuitive client API.</description>
     <jetty.version>9.4.56.v20240826</jetty.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <jersey.version>2.42</jersey.version>
-    <athenz.version>1.10.50</athenz.version>
+    <athenz.version>1.10.62</athenz.version>
     <prometheus.version>0.16.0</prometheus.version>
     <vertx.version>4.5.10</vertx.version>
     <rocksdb.version>7.9.2</rocksdb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@ flexible messaging model and an intuitive client API.</description>
     <docker.tag>latest</docker.tag>
     <skipSourceReleaseAssembly>false</skipSourceReleaseAssembly>
     <skipBuildDistribution>false</skipBuildDistribution>
+    <skipDeployConnector>false</skipDeployConnector>
     <shadePluginPhase>package</shadePluginPhase>
     <narPluginPhase>package</narPluginPhase>
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -624,7 +624,12 @@ public abstract class AdminResource extends PulsarWebResource {
                     asyncResponse.resume(Response.noContent().build());
                 })
                 .exceptionally(ex -> {
-                    log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, ex);
+                    if (AdminResource.isConflictException(ex)) {
+                        log.info("[{}] Failed to create partitioned topic {}: {}", clientAppId(), topicName,
+                                ex.getMessage());
+                    } else {
+                        log.error("[{}] Failed to create partitioned topic {}", clientAppId(), topicName, ex);
+                    }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
                     return null;
                 });
@@ -885,11 +890,22 @@ public abstract class AdminResource extends PulsarWebResource {
                 == Status.TEMPORARY_REDIRECT.getStatusCode();
     }
 
+    protected static boolean isNotFoundOrConflictException(Throwable ex) {
+        return isNotFoundException(ex) || isConflictException(ex);
+    }
+
     protected static boolean isNotFoundException(Throwable ex) {
         Throwable realCause = FutureUtil.unwrapCompletionException(ex);
         return realCause instanceof WebApplicationException
                 && ((WebApplicationException) realCause).getResponse().getStatus()
                 == Status.NOT_FOUND.getStatusCode();
+    }
+
+    protected static boolean isConflictException(Throwable ex) {
+        Throwable realCause = FutureUtil.unwrapCompletionException(ex);
+        return realCause instanceof WebApplicationException
+                && ((WebApplicationException) realCause).getResponse().getStatus()
+                == Status.CONFLICT.getStatusCode();
     }
 
     protected static boolean isNot307And404Exception(Throwable ex) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -47,6 +47,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
+import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.admin.impl.NamespacesBase;
 import org.apache.pulsar.broker.admin.impl.OffloaderObjectsScannerUtils;
 import org.apache.pulsar.broker.web.RestException;
@@ -154,7 +155,11 @@ public class Namespaces extends NamespacesBase {
                 .thenCompose(__ -> getNamespacePoliciesAsync(namespaceName))
                 .thenAccept(response::resume)
                 .exceptionally(ex -> {
-                    log.error("Failed to get policies for namespace {}", namespaceName, ex);
+                    if (AdminResource.isNotFoundOrConflictException(ex)) {
+                        log.info("Failed to get policies for namespace {}: {}", namespaceName, ex.getMessage());
+                    } else {
+                        log.error("Failed to get policies for namespace {}", namespaceName, ex);
+                    }
                     resumeAsyncResponseExceptionally(response, ex);
                     return null;
                 });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -346,7 +346,7 @@ public class PersistentTopics extends PersistentTopicsBase {
         internalCreateNonPartitionedTopicAsync(authoritative, properties)
                 .thenAccept(__ -> asyncResponse.resume(Response.noContent().build()))
                 .exceptionally(ex -> {
-                    if (isNot307And404Exception(ex)) {
+                    if (isNot307And404Exception(ex) && !isConflictException(ex)) {
                         log.error("[{}] Failed to create non-partitioned topic {}", clientAppId(), topicName, ex);
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);
@@ -946,7 +946,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                     Throwable t = FutureUtil.unwrapCompletionException(ex);
                     if (!isRedirectException(t)) {
                         if (AdminResource.isNotFoundException(t)) {
-                            log.error("[{}] Failed to get partitioned metadata topic {}: {}",
+                            log.info("[{}] Failed to get partitioned metadata topic {}: {}",
                                     clientAppId(), topicName, ex.getMessage());
                         } else {
                             log.error("[{}] Failed to get partitioned metadata topic {}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/AsyncTokenBucketBuilder.java
@@ -23,6 +23,8 @@ package org.apache.pulsar.broker.qos;
 public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuilder<SELF>> {
     protected MonotonicSnapshotClock clock = AsyncTokenBucket.DEFAULT_SNAPSHOT_CLOCK;
     protected long resolutionNanos = AsyncTokenBucket.defaultResolutionNanos;
+    protected boolean consistentConsumedTokens;
+    protected boolean consistentAddedTokens;
 
     protected AsyncTokenBucketBuilder() {
     }
@@ -31,13 +33,45 @@ public abstract class AsyncTokenBucketBuilder<SELF extends AsyncTokenBucketBuild
         return (SELF) this;
     }
 
+    /**
+     * Set the clock source for the token bucket. It's recommended to use the {@link DefaultMonotonicSnapshotClock}
+     * for most use cases.
+     */
     public SELF clock(MonotonicSnapshotClock clock) {
         this.clock = clock;
         return self();
     }
 
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the token balance is updated, when time
+     * advances more than the configured resolution. This setting determines the duration of the increment.
+     * Setting this value to 0 will make the token balance fully consistent. There's a performance trade-off
+     * when setting this value to 0.
+     */
     public SELF resolutionNanos(long resolutionNanos) {
         this.resolutionNanos = resolutionNanos;
+        return self();
+    }
+
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the consumed tokens are subtracted from
+     * the total amount of tokens at most once during each "increment", when time advances more than the configured
+     * resolution. This setting determines if the consumed tokens are subtracted from tokens balance consistently.
+     * For high performance, it is recommended to keep this setting as false.
+     */
+    public SELF consistentConsumedTokens(boolean consistentConsumedTokens) {
+        this.consistentConsumedTokens = consistentConsumedTokens;
+        return self();
+    }
+
+    /**
+     * By default, AsyncTokenBucket is eventually consistent. This means that the added tokens are calculated based
+     * on elapsed time at most once during each "increment", when time advances more than the configured
+     * resolution. This setting determines if the added tokens are calculated and added to tokens balance consistently.
+     * For high performance, it is recommended to keep this setting as false.
+     */
+    public SELF consistentAddedTokens(boolean consistentAddedTokens) {
+        this.consistentAddedTokens = consistentAddedTokens;
         return self();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClock.java
@@ -19,71 +19,269 @@
 
 package org.apache.pulsar.broker.qos;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Default implementation of {@link MonotonicSnapshotClock}.
+ * Default implementation of {@link MonotonicSnapshotClock} optimized for use with {@link AsyncTokenBucket}.
  *
- * Starts a daemon thread that updates the snapshot value periodically with a configured interval. The close method
- * should be called to stop the thread.
+ * <p>
+ * This class provides a monotonic snapshot value that consistently increases, ensuring reliable behavior
+ * even in environments where the underlying clock source may not be strictly monotonic across all CPUs,
+ * such as certain virtualized platforms.
+ * </p>
+ *
+ * <p>
+ * Upon instantiation, a daemon thread is launched to periodically update the snapshot value at a configured
+ * interval. It is essential to invoke the {@link #close()} method to gracefully terminate this thread when it is
+ * no longer needed.
+ * </p>
+ *
+ * <p>
+ * The {@link AsyncTokenBucket} utilizes this clock to obtain tick values. It does not require a consistent value on
+ * every retrieval. However, when a consistent snapshot is necessary, the {@link #getTickNanos(boolean)} method
+ * is called with the {@code requestSnapshot} parameter set to {@code true}.
+ * </p>
+ *
+ * <p>
+ * By employing a single thread to update the monotonic clock value, this implementation ensures that the snapshot
+ * value remains strictly increasing. This approach mitigates potential inconsistencies that may arise from clock
+ * source discrepancies across different CPUs.
+ * </p>
  */
 public class DefaultMonotonicSnapshotClock implements MonotonicSnapshotClock, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMonotonicSnapshotClock.class);
-    private final long sleepMillis;
-    private final int sleepNanos;
-    private final LongSupplier clockSource;
-    private final Thread thread;
+    private final TickUpdaterThread tickUpdaterThread;
     private volatile long snapshotTickNanos;
 
     public DefaultMonotonicSnapshotClock(long snapshotIntervalNanos, LongSupplier clockSource) {
         if (snapshotIntervalNanos < TimeUnit.MILLISECONDS.toNanos(1)) {
             throw new IllegalArgumentException("snapshotIntervalNanos must be at least 1 millisecond");
         }
-        this.sleepMillis = TimeUnit.NANOSECONDS.toMillis(snapshotIntervalNanos);
-        this.sleepNanos = (int) (snapshotIntervalNanos - TimeUnit.MILLISECONDS.toNanos(sleepMillis));
-        this.clockSource = clockSource;
-        updateSnapshotTickNanos();
-        thread = new Thread(this::snapshotLoop, getClass().getSimpleName() + "-update-loop");
-        thread.setDaemon(true);
-        thread.start();
+        tickUpdaterThread = new TickUpdaterThread(snapshotIntervalNanos,
+                Objects.requireNonNull(clockSource, "clockSource must not be null"), this::setSnapshotTickNanos);
+        tickUpdaterThread.start();
+    }
+
+    private void setSnapshotTickNanos(long snapshotTickNanos) {
+        this.snapshotTickNanos = snapshotTickNanos;
     }
 
     /** {@inheritDoc} */
     @Override
     public long getTickNanos(boolean requestSnapshot) {
         if (requestSnapshot) {
-            updateSnapshotTickNanos();
+            tickUpdaterThread.requestUpdateAndWait();
         }
         return snapshotTickNanos;
     }
 
-    private void updateSnapshotTickNanos() {
-        snapshotTickNanos = clockSource.getAsLong();
+    @Override
+    public void close() {
+        tickUpdaterThread.interrupt();
     }
 
-    private void snapshotLoop() {
-        try {
-            while (!Thread.currentThread().isInterrupted()) {
-                updateSnapshotTickNanos();
+    /**
+     * A thread that updates snapshotTickNanos value periodically with a configured interval.
+     * The thread is started when the DefaultMonotonicSnapshotClock is created and runs until the close method is
+     * called.
+     * A single thread is used to read the clock source value since on some hardware of virtualized platforms,
+     * System.nanoTime() isn't strictly monotonic across all CPUs. Reading by a single thread will improve the
+     * stability of the read value since a single thread is scheduled on a single CPU. If the thread is migrated
+     * to another CPU, the clock source value might leap backward or forward, but logic in this class will handle it.
+     */
+    private static class TickUpdaterThread extends Thread {
+        private final Object tickUpdateDelayMonitor = new Object();
+        private final Object tickUpdatedMonitor = new Object();
+        private final MonotonicLeapDetectingTickUpdater tickUpdater;
+        private volatile boolean running;
+        private boolean tickUpdateDelayMonitorNotified;
+        private AtomicLong requestCount = new AtomicLong();
+        private final long sleepMillis;
+        private final int sleepNanos;
+
+        TickUpdaterThread(long snapshotIntervalNanos, LongSupplier clockSource, LongConsumer setSnapshotTickNanos) {
+            super(DefaultMonotonicSnapshotClock.class.getSimpleName() + "-update-loop");
+            // set as daemon thread so that it doesn't prevent the JVM from exiting
+            setDaemon(true);
+            // set the highest priority
+            setPriority(MAX_PRIORITY);
+            this.sleepMillis = TimeUnit.NANOSECONDS.toMillis(snapshotIntervalNanos);
+            this.sleepNanos = (int) (snapshotIntervalNanos - TimeUnit.MILLISECONDS.toNanos(sleepMillis));
+            tickUpdater = new MonotonicLeapDetectingTickUpdater(clockSource, setSnapshotTickNanos,
+                    snapshotIntervalNanos);
+        }
+
+        @Override
+        public void run() {
+            try {
+                running = true;
+                long updatedForRequestCount = -1;
+                while (!isInterrupted()) {
+                    try {
+                        // track if the thread has waited for the whole duration of the snapshot interval
+                        // before updating the tick value
+                        boolean waitedSnapshotInterval = false;
+                        // sleep for the configured interval on a monitor that can be notified to stop the sleep
+                        // and update the tick value immediately. This is used in requestUpdate method.
+                        synchronized (tickUpdateDelayMonitor) {
+                            tickUpdateDelayMonitorNotified = false;
+                            // only wait if no explicit request has been made since the last update
+                            if (requestCount.get() == updatedForRequestCount) {
+                                // if no request has been made, sleep for the configured interval
+                                tickUpdateDelayMonitor.wait(sleepMillis, sleepNanos);
+                                waitedSnapshotInterval = !tickUpdateDelayMonitorNotified;
+                            }
+                        }
+                        updatedForRequestCount = requestCount.get();
+                        // update the tick value using the tick updater which will tolerate leaps backward
+                        tickUpdater.update(waitedSnapshotInterval);
+                        notifyAllTickUpdated();
+                    } catch (InterruptedException e) {
+                        interrupt();
+                        break;
+                    }
+                }
+            } catch (Throwable t) {
+                // report unexpected error since this would be a fatal error when the clock doesn't progress anymore
+                // this is very unlikely to happen, but it's better to log it in any case
+                LOG.error("Unexpected fatal error that stopped the clock.", t);
+            } finally {
+                LOG.info("DefaultMonotonicSnapshotClock's TickUpdaterThread stopped. {},tid={}", this, getId());
+                running = false;
+                notifyAllTickUpdated();
+            }
+        }
+
+        private void notifyAllTickUpdated() {
+            synchronized (tickUpdatedMonitor) {
+                // notify all threads that are waiting for the tick value to be updated
+                tickUpdatedMonitor.notifyAll();
+            }
+        }
+
+        public void requestUpdateAndWait() {
+            if (!running) {
+                synchronized (tickUpdater) {
+                    // thread has stopped running, fallback to update the value directly without optimizations
+                    tickUpdater.update(false);
+                }
+                return;
+            }
+            // increment the request count that ensures that the thread will update the tick value after this request
+            // was made also when there's a race condition between the request and the update
+            // this solution doesn't prevent all races, and it's not guaranteed that the tick value is always updated
+            // it will prevent the request having to wait for the delayed update cycle. This is sufficient for the
+            // use case.
+            requestCount.incrementAndGet();
+            synchronized (tickUpdatedMonitor) {
+                // notify the thread to stop waiting and update the tick value
+                synchronized (tickUpdateDelayMonitor) {
+                    tickUpdateDelayMonitorNotified = true;
+                    tickUpdateDelayMonitor.notify();
+                }
+                // wait until the tick value has been updated
                 try {
-                    Thread.sleep(sleepMillis, sleepNanos);
+                    tickUpdatedMonitor.wait();
                 } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
+                    currentThread().interrupt();
                 }
             }
-        } catch (Throwable t) {
-            // report unexpected error since this would be a fatal error when the clock doesn't progress anymore
-            // this is very unlikely to happen, but it's better to log it in any case
-            LOG.error("Unexpected fatal error that stopped the clock.", t);
+        }
+
+        @Override
+        public synchronized void start() {
+            // wait until the thread is started and the tick value has been updated
+            synchronized (tickUpdatedMonitor) {
+                super.start();
+                try {
+                    tickUpdatedMonitor.wait();
+                } catch (InterruptedException e) {
+                    currentThread().interrupt();
+                }
+            }
         }
     }
 
-    @Override
-    public void close() {
-        thread.interrupt();
+    /**
+     * Handles updating the tick value in a monotonic way so that the value is always increasing,
+     * regardless of leaps backward in the clock source value.
+     */
+    static class MonotonicLeapDetectingTickUpdater {
+        private final LongSupplier clockSource;
+        private final long snapshotInternalNanos;
+        private final long maxDeltaNanosForLeapDetection;
+        private final LongConsumer tickUpdatedCallback;
+        private long referenceClockSourceValue = Long.MIN_VALUE;
+        private long baseSnapshotTickNanos;
+        private long previousSnapshotTickNanos;
+
+        MonotonicLeapDetectingTickUpdater(LongSupplier clockSource, LongConsumer tickUpdatedCallback,
+                                          long snapshotInternalNanos) {
+            this.clockSource = clockSource;
+            this.snapshotInternalNanos = snapshotInternalNanos;
+            this.maxDeltaNanosForLeapDetection = 2 * snapshotInternalNanos;
+            this.tickUpdatedCallback = tickUpdatedCallback;
+        }
+
+        /**
+         * Updates the snapshot tick value. The tickUpdatedCallback is called if the value has changed.
+         * The value is updated in a monotonic way so that the value is always increasing, regardless of leaps backward
+         * in the clock source value.
+         * Leap detection is done by comparing the new value with the previous value and the maximum delta value.
+         *
+         * @param waitedSnapshotInterval if true, the method has waited for the snapshot interval since the previous
+         *                               call.
+         */
+        public void update(boolean waitedSnapshotInterval) {
+            // get the current clock source value
+            long clockValue = clockSource.getAsLong();
+
+            // Initialization on first call
+            if (referenceClockSourceValue == Long.MIN_VALUE) {
+                referenceClockSourceValue = clockValue;
+                baseSnapshotTickNanos = clockValue;
+                previousSnapshotTickNanos = clockValue;
+                // update the tick value using the callback
+                tickUpdatedCallback.accept(clockValue);
+                return;
+            }
+
+            // calculate the duration since the reference clock source value
+            // so that the snapshot value is always increasing and tolerates it when the clock source is not strictly
+            // monotonic across all CPUs and leaps backward
+            long durationSinceReference = clockValue - referenceClockSourceValue;
+            // calculate the new snapshot tick value as a duration since the reference clock source value
+            // and add it to the base snapshot tick value
+            long newSnapshotTickNanos = baseSnapshotTickNanos + durationSinceReference;
+
+            // reset the reference clock source value if the clock source value leaps backward
+            // more than the maximum delta value
+            if (newSnapshotTickNanos < previousSnapshotTickNanos - maxDeltaNanosForLeapDetection) {
+                // when the clock source value leaps backward, reset the reference value to the new value
+                // for future duration calculations
+                referenceClockSourceValue = clockValue;
+                // if the updater thread has waited for the snapshot interval since the previous call,
+                // increment the base snapshot tick value by the snapshot interval value
+                long incrementWhenLeapDetected = waitedSnapshotInterval ? snapshotInternalNanos : 0;
+                // set the base snapshot tick value to the new value
+                baseSnapshotTickNanos = previousSnapshotTickNanos + incrementWhenLeapDetected;
+                // set the new snapshot tick value to the base value
+                newSnapshotTickNanos = baseSnapshotTickNanos;
+            }
+
+            // update snapshotTickNanos value if the new value is greater than the previous value
+            if (newSnapshotTickNanos > previousSnapshotTickNanos) {
+                // store the previous value
+                previousSnapshotTickNanos = newSnapshotTickNanos;
+                // update the tick value using the callback
+                tickUpdatedCallback.accept(newSnapshotTickNanos);
+            }
+        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucket.java
@@ -34,15 +34,16 @@ public class DynamicRateAsyncTokenBucket extends AsyncTokenBucket {
 
     protected DynamicRateAsyncTokenBucket(double capacityFactor, LongSupplier rateFunction,
                                           MonotonicSnapshotClock clockSource, LongSupplier ratePeriodNanosFunction,
-                                          long resolutionNanos, double initialTokensFactor,
+                                          long resolutionNanos, boolean consistentConsumedTokens,
+                                          boolean consistentAddedTokens, double initialTokensFactor,
                                           double targetFillFactorAfterThrottling) {
-        super(clockSource, resolutionNanos);
+        super(clockSource, resolutionNanos, consistentConsumedTokens, consistentAddedTokens);
         this.capacityFactor = capacityFactor;
         this.rateFunction = rateFunction;
         this.ratePeriodNanosFunction = ratePeriodNanosFunction;
         this.targetFillFactorAfterThrottling = targetFillFactorAfterThrottling;
         this.tokens = (long) (rateFunction.getAsLong() * initialTokensFactor);
-        tokens(false);
+        getTokens();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/DynamicRateAsyncTokenBucketBuilder.java
@@ -64,9 +64,7 @@ public class DynamicRateAsyncTokenBucketBuilder
     @Override
     public AsyncTokenBucket build() {
         return new DynamicRateAsyncTokenBucket(this.capacityFactor, this.rateFunction,
-                this.clock,
-                this.ratePeriodNanosFunction, this.resolutionNanos,
-                this.initialFillFactor,
-                targetFillFactorAfterThrottling);
+                this.clock, this.ratePeriodNanosFunction, this.resolutionNanos, this.consistentConsumedTokens,
+                this.consistentAddedTokens, this.initialFillFactor, targetFillFactorAfterThrottling);
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucket.java
@@ -30,15 +30,16 @@ class FinalRateAsyncTokenBucket extends AsyncTokenBucket {
     private final long targetAmountOfTokensAfterThrottling;
 
     protected FinalRateAsyncTokenBucket(long capacity, long rate, MonotonicSnapshotClock clockSource,
-                                        long ratePeriodNanos, long resolutionNanos, long initialTokens) {
-        super(clockSource, resolutionNanos);
+                                        long ratePeriodNanos, long resolutionNanos, boolean consistentConsumedTokens,
+                                        boolean consistentAddedTokens, long initialTokens) {
+        super(clockSource, resolutionNanos, consistentConsumedTokens, consistentAddedTokens);
         this.capacity = capacity;
         this.rate = rate;
         this.ratePeriodNanos = ratePeriodNanos != -1 ? ratePeriodNanos : ONE_SECOND_NANOS;
         // The target amount of tokens is the amount of tokens made available in the resolution duration
         this.targetAmountOfTokensAfterThrottling = Math.max(this.resolutionNanos * rate / ratePeriodNanos, 1);
         this.tokens = initialTokens;
-        tokens(false);
+        getTokens();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/qos/FinalRateAsyncTokenBucketBuilder.java
@@ -55,7 +55,7 @@ public class FinalRateAsyncTokenBucketBuilder
     public AsyncTokenBucket build() {
         return new FinalRateAsyncTokenBucket(this.capacity != null ? this.capacity : this.rate, this.rate,
                 this.clock,
-                this.ratePeriodNanos, this.resolutionNanos,
+                this.ratePeriodNanos, this.resolutionNanos, this.consistentConsumedTokens, this.consistentAddedTokens,
                 this.initialTokens != null ? this.initialTokens : this.rate
         );
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -48,6 +48,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.ToLongFunction;
 import javax.annotation.Nonnull;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.bookkeeper.mledger.util.StatsBuckets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -95,6 +96,13 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener {
     protected static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
 
     protected final String topic;
+
+    // Reference to the CompletableFuture returned when creating this topic in BrokerService.
+    // Used to safely remove the topic from BrokerService's cache by ensuring we remove the exact
+    // topic instance that was created.
+    @Getter
+    @Setter
+    protected volatile CompletableFuture<Optional<Topic>> createFuture;
 
     // Producers currently connected to this topic
     protected final ConcurrentHashMap<String, Producer> producers;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1326,6 +1326,7 @@ public class BrokerService implements Closeable {
         NonPersistentTopic nonPersistentTopic;
         try {
             nonPersistentTopic = newTopic(topic, null, this, NonPersistentTopic.class);
+            nonPersistentTopic.setCreateFuture(topicFuture);
         } catch (Throwable e) {
             log.warn("Failed to create topic {}", topic, e);
             topicFuture.completeExceptionally(e);
@@ -1800,6 +1801,7 @@ public class BrokerService implements Closeable {
                                 PersistentTopic persistentTopic = isSystemTopic(topic)
                                         ? new SystemTopic(topic, ledger, BrokerService.this)
                                         : newTopic(topic, ledger, BrokerService.this, PersistentTopic.class);
+                                persistentTopic.setCreateFuture(topicFuture);
                                 persistentTopic
                                         .initialize()
                                         .thenCompose(__ -> persistentTopic.preCreateSubscriptionForCompactionIfNeeded())
@@ -2409,47 +2411,18 @@ public class BrokerService implements Closeable {
         return authorizationService;
     }
 
-    public CompletableFuture<Void> removeTopicFromCache(Topic topic) {
-        Optional<CompletableFuture<Optional<Topic>>> createTopicFuture = findTopicFutureInCache(topic);
-        if (createTopicFuture.isEmpty()){
-            return CompletableFuture.completedFuture(null);
-        }
-        return removeTopicFutureFromCache(topic.getName(), createTopicFuture.get());
-    }
-
-    private Optional<CompletableFuture<Optional<Topic>>> findTopicFutureInCache(Topic topic){
-        if (topic == null){
-            return Optional.empty();
-        }
-        final CompletableFuture<Optional<Topic>> createTopicFuture = topics.get(topic.getName());
-        // If not exists in cache, do nothing.
-        if (createTopicFuture == null){
-            return Optional.empty();
-        }
-        // If the future in cache is not yet complete, the topic instance in the cache is not the same with the topic.
-        if (!createTopicFuture.isDone()){
-            return Optional.empty();
-        }
-        // If the future in cache has exception complete,
-        // the topic instance in the cache is not the same with the topic.
-        if (createTopicFuture.isCompletedExceptionally()){
-            return Optional.empty();
-        }
-        Optional<Topic> optionalTopic = createTopicFuture.join();
-        Topic topicInCache = optionalTopic.orElse(null);
-        if (topicInCache == null || topicInCache != topic){
-            return Optional.empty();
-        } else {
-            return Optional.of(createTopicFuture);
-        }
-    }
-
-    private CompletableFuture<Void> removeTopicFutureFromCache(String topic,
-                                                        CompletableFuture<Optional<Topic>> createTopicFuture) {
-        TopicName topicName = TopicName.get(topic);
+    /**
+     * Removes the topic from the cache only if the topicName and associated createFuture match exactly.
+     * The TopicEvent.UNLOAD event will be triggered before and after removal.
+     *
+     * @param topic The topic to be removed.
+     * @return A CompletableFuture that completes when the operation is done.
+     */
+    public CompletableFuture<Void> removeTopicFromCache(AbstractTopic topic) {
+        TopicName topicName = TopicName.get(topic.getName());
         return pulsar.getNamespaceService().getBundleAsync(topicName)
                 .thenAccept(namespaceBundle -> {
-                    removeTopicFromCache(topic, namespaceBundle, createTopicFuture);
+                    removeTopicFromCache(topic.getName(), namespaceBundle, topic.getCreateFuture());
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2479,6 +2479,12 @@ public class BrokerService implements Closeable {
 
 
     private void handleMetadataChanges(Notification n) {
+        if (!pulsar.isRunning()) {
+            // Ignore metadata changes when broker is not running
+            log.info("Ignoring metadata change since broker is not running (id={}, state={}) {}", pulsar.getBrokerId(),
+                    pulsar.getState(), n);
+            return;
+        }
         if (n.getType() == NotificationType.Modified && NamespaceResources.pathIsFromNamespace(n.getPath())) {
             NamespaceName ns = NamespaceResources.namespaceFromPath(n.getPath());
             handlePoliciesUpdates(ns);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -218,6 +218,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class ConnectionClosedException extends BrokerServiceException {
+        public ConnectionClosedException(String msg) {
+            super(msg);
+        }
+    }
+
     public static class TopicBacklogQuotaExceededException extends BrokerServiceException {
         @Getter
         private final BacklogQuota.RetentionPolicy retentionPolicy;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PublishRateLimiterImpl.java
@@ -20,11 +20,11 @@
 package org.apache.pulsar.broker.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.netty.channel.EventLoopGroup;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.qos.MonotonicSnapshotClock;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -32,6 +32,7 @@ import org.apache.pulsar.common.policies.data.PublishRate;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 
+@Slf4j
 public class PublishRateLimiterImpl implements PublishRateLimiter {
     private volatile AsyncTokenBucket tokenBucketOnMessage;
     private volatile AsyncTokenBucket tokenBucketOnByte;
@@ -80,7 +81,7 @@ public class PublishRateLimiterImpl implements PublishRateLimiter {
         // schedule unthrottling when the throttling count is incremented to 1
         // this is to avoid scheduling unthrottling multiple times for concurrent producers
         if (throttledProducersCount.incrementAndGet() == 1) {
-            EventLoopGroup executor = producer.getCnx().getBrokerService().executor();
+            ScheduledExecutorService executor = producer.getCnx().getBrokerService().executor().next();
             scheduleUnthrottling(executor, calculateThrottlingDurationNanos());
         }
     }
@@ -134,7 +135,11 @@ public class PublishRateLimiterImpl implements PublishRateLimiter {
             // unthrottle as many producers as possible while there are token available
             while ((throttlingDuration = calculateThrottlingDurationNanos()) == 0L
                     && (producer = unthrottlingQueue.poll()) != null) {
-                producer.decrementThrottleCount();
+                try {
+                    producer.decrementThrottleCount();
+                } catch (Exception e) {
+                    log.error("Failed to unthrottle producer {}", producer, e);
+                }
                 throttledProducersCount.decrementAndGet();
             }
             // if there are still producers to be unthrottled, schedule unthrottling again

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1729,7 +1729,8 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                     log.warn("[{}] Failed to load topic {}, producerId={}: Topic not found", remoteAddress, topicName,
                             producerId);
                 } else if (!Exceptions.areExceptionsPresentInChain(cause,
-                        ServiceUnitNotReadyException.class, ManagedLedgerException.class)) {
+                        ServiceUnitNotReadyException.class, ManagedLedgerException.class,
+                        BrokerServiceException.ProducerBusyException.class)) {
                     log.error("[{}] Failed to create topic {}, producerId={}",
                             remoteAddress, topicName, producerId, exception);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1627,8 +1627,12 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                                     BrokerServiceException.getClientErrorCode(exception),
                                     message);
                         }
-                        log.error("Try add schema failed, remote address {}, topic {}, producerId {}", remoteAddress,
-                                topicName, producerId, exception);
+                        var cause = FutureUtil.unwrapCompletionException(exception);
+                        if (!(cause instanceof IncompatibleSchemaException)) {
+                            log.error("Try add schema failed, remote address {}, topic {}, producerId {}",
+                                    remoteAddress,
+                                    topicName, producerId, exception);
+                        }
                         producers.remove(producerId, producerFuture);
                         return null;
                     });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -351,7 +351,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
                                 consumer.consumerName(), currentUsageCount());
                     }
                     future.completeExceptionally(
-                            new BrokerServiceException("Connection was closed while the opening the cursor "));
+                            new BrokerServiceException.ConnectionClosedException(
+                                    "Connection was closed while the opening the cursor "));
                 } else {
                     log.info("[{}][{}] Created new subscription for {}", topic, subscriptionName, consumerId);
                     future.complete(consumer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1031,7 +1031,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
 
                         decrementUsageCount();
                         return FutureUtil.failedFuture(
-                                new BrokerServiceException("Connection was closed while the opening the cursor "));
+                                new BrokerServiceException.ConnectionClosedException(
+                                        "Connection was closed while the opening the cursor "));
                     } else {
                         checkReplicatedSubscriptionControllerState();
                         if (log.isDebugEnabled()) {
@@ -1068,6 +1069,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                     log.warn("[{}][{}] has been fenced. closing the topic {}", topic, subscriptionName,
                             ex.getMessage());
                     close();
+                } else if (ex.getCause() instanceof BrokerServiceException.ConnectionClosedException) {
+                    log.warn("[{}][{}] Connection was closed while the opening the cursor", topic, subscriptionName);
                 } else {
                     log.error("[{}] Failed to create subscription: {}", topic, subscriptionName, ex);
                 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/SubscribeRateLimiter.java
@@ -70,7 +70,7 @@ public class SubscribeRateLimiter {
         if (tokenBucket == null) {
             return true;
         }
-        if (!tokenBucket.containsTokens(true)) {
+        if (!tokenBucket.containsTokens()) {
             return false;
         }
         tokenBucket.consumeTokens(1);
@@ -117,7 +117,11 @@ public class SubscribeRateLimiter {
         // update subscribe-rateLimiter
         if (ratePerConsumer > 0) {
             AsyncTokenBucket tokenBucket =
-                    AsyncTokenBucket.builder().rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
+                    AsyncTokenBucket.builder()
+                            .consistentAddedTokens(true)
+                            .consistentConsumedTokens(true)
+                            .clock(brokerService.getPulsar().getMonotonicSnapshotClock())
+                            .rate(ratePerConsumer).ratePeriodNanos(ratePeriodNanos).build();
             this.subscribeRateLimiter.put(consumerIdentifier, tokenBucket);
         } else {
             // subscribe-rate should be disable and close

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/intercept/ManagedLedgerInterceptorImplTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.intercept;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -29,9 +30,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import lombok.Cleanup;
@@ -499,4 +503,53 @@ public class ManagedLedgerInterceptorImplTest  extends MockedBookKeeperTestCase 
         ledger.close();
     }
 
+    @Test
+    public void testBeforeAddEntry() throws Exception {
+        final var interceptor = new ManagedLedgerInterceptorImpl(getBrokerEntryMetadataInterceptors(), null);
+        final var config = new ManagedLedgerConfig();
+        final var numEntries = 100;
+        config.setMaxEntriesPerLedger(numEntries);
+        config.setManagedLedgerInterceptor(interceptor);
+        @Cleanup final var ml = (ManagedLedgerImpl) factory.open("test_concurrent_add_entry", config);
+
+        final var indexesBeforeAdd = new ArrayList<Long>();
+        final var batchSizes = new ArrayList<Long>();
+        final var random = new Random();
+        final var latch = new CountDownLatch(numEntries);
+        final var executor = Executors.newFixedThreadPool(3);
+        final var lock = new Object(); // make sure `asyncAddEntry` are called in order
+        for (int i = 0; i < numEntries; i++) {
+            final var batchSize = random.nextInt(0, 100);
+            final var msg = "msg-" + i;
+            final var callback = new AsyncCallbacks.AddEntryCallback() {
+
+                @Override
+                public void addComplete(Position position, ByteBuf entryData, Object ctx) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void addFailed(ManagedLedgerException exception, Object ctx) {
+                    log.error("Failed to add {}", msg, exception);
+                    latch.countDown();
+                }
+            };
+            executor.execute(() -> {
+                synchronized (lock) {
+                    batchSizes.add((long) batchSize);
+                    indexesBeforeAdd.add(interceptor.getIndex() + 1); // index is updated in each asyncAddEntry call
+                    ml.asyncAddEntry(Unpooled.wrappedBuffer(msg.getBytes()), batchSize, callback, null);
+                }
+            });
+        }
+        assertTrue(latch.await(3, TimeUnit.SECONDS));
+        synchronized (lock) {
+            for (int i = 1; i < numEntries; i++) {
+                final var sum = batchSizes.get(i) + batchSizes.get(i - 1);
+                batchSizes.set(i, sum);
+            }
+            assertEquals(indexesBeforeAdd.subList(1, numEntries), batchSizes.subList(0, numEntries - 1));
+        }
+        executor.shutdown();
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/AsyncTokenBucketTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.pulsar.broker.qos;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -50,7 +51,8 @@ public class AsyncTokenBucketTest {
     @Test
     void shouldAddTokensWithConfiguredRate() {
         asyncTokenBucket =
-                AsyncTokenBucket.builder().capacity(100).rate(10).initialTokens(0).clock(clockSource).build();
+                AsyncTokenBucket.builder().consistentConsumedTokens(true)
+                        .capacity(100).rate(10).initialTokens(0).clock(clockSource).build();
         incrementSeconds(5);
         assertEquals(asyncTokenBucket.getTokens(), 50);
         incrementSeconds(1);
@@ -64,7 +66,7 @@ public class AsyncTokenBucketTest {
 
         // Consume all and verify none available and then wait 1 period and check replenished
         asyncTokenBucket.consumeTokens(100);
-        assertEquals(asyncTokenBucket.tokens(true), 0);
+        assertEquals(asyncTokenBucket.getTokens(), 0);
         incrementSeconds(1);
         assertEquals(asyncTokenBucket.getTokens(), 10);
     }
@@ -91,13 +93,148 @@ public class AsyncTokenBucketTest {
     @Test
     void shouldSupportFractionsAndRetainLeftoverWhenUpdatingTokens() {
         asyncTokenBucket =
-                AsyncTokenBucket.builder().capacity(100).rate(10).initialTokens(0).clock(clockSource).build();
+                AsyncTokenBucket.builder().capacity(100)
+                        .resolutionNanos(TimeUnit.MILLISECONDS.toNanos(1))
+                        .rate(10)
+                        .initialTokens(0)
+                        .clock(clockSource)
+                        .build();
         for (int i = 0; i < 150; i++) {
             incrementMillis(1);
         }
         assertEquals(asyncTokenBucket.getTokens(), 1);
         incrementMillis(150);
         assertEquals(asyncTokenBucket.getTokens(), 3);
+        incrementMillis(1);
+        assertEquals(asyncTokenBucket.getTokens(), 3);
+        incrementMillis(99);
+        assertEquals(asyncTokenBucket.getTokens(), 4);
     }
 
+    @Test
+    void shouldSupportFractionsAndRetainLeftoverWhenUpdatingTokens2() {
+        asyncTokenBucket =
+                AsyncTokenBucket.builder().capacity(100)
+                        .resolutionNanos(TimeUnit.MILLISECONDS.toNanos(1))
+                        .rate(1)
+                        .initialTokens(0)
+                        .clock(clockSource)
+                        .build();
+        for (int i = 0; i < 150; i++) {
+            incrementMillis(1);
+            assertEquals(asyncTokenBucket.getTokens(), 0);
+        }
+        incrementMillis(150);
+        assertEquals(asyncTokenBucket.getTokens(), 0);
+        incrementMillis(699);
+        assertEquals(asyncTokenBucket.getTokens(), 0);
+        incrementMillis(1);
+        assertEquals(asyncTokenBucket.getTokens(), 1);
+        incrementMillis(1000);
+        assertEquals(asyncTokenBucket.getTokens(), 2);
+    }
+
+    @Test
+    void shouldHandleNegativeBalanceWithEventuallyConsistentTokenUpdates() {
+        asyncTokenBucket =
+                AsyncTokenBucket.builder()
+                        // intentionally pick a coarse resolution
+                        .resolutionNanos(TimeUnit.SECONDS.toNanos(51))
+                        .capacity(100).rate(10).initialTokens(0).clock(clockSource).build();
+        // assert that the token balance is 0 initially
+        assertThat(asyncTokenBucket.getTokens()).isEqualTo(0);
+
+        // consume tokens without exceeding the rate
+        for (int i = 0; i < 10000; i++) {
+            asyncTokenBucket.consumeTokens(500);
+            incrementSeconds(50);
+        }
+
+        // let 9 seconds pass
+        incrementSeconds(9);
+
+        // there should be 90 tokens available
+        assertThat(asyncTokenBucket.getTokens()).isEqualTo(90);
+    }
+
+    @Test
+    void shouldNotExceedTokenBucketSizeWithNegativeTokens() {
+        asyncTokenBucket =
+                AsyncTokenBucket.builder()
+                        // intentionally pick a coarse resolution
+                        .resolutionNanos(TimeUnit.SECONDS.toNanos(51))
+                        .capacity(100).rate(10).initialTokens(0).clock(clockSource).build();
+        // assert that the token balance is 0 initially
+        assertThat(asyncTokenBucket.getTokens()).isEqualTo(0);
+
+        // consume tokens without exceeding the rate
+        for (int i = 0; i < 100; i++) {
+            asyncTokenBucket.consumeTokens(600);
+            incrementSeconds(50);
+            // let tokens accumulate back to 0 every 10 seconds
+            if ((i + 1) % 10 == 0) {
+                incrementSeconds(100);
+            }
+        }
+
+        // let 9 seconds pass
+        incrementSeconds(9);
+
+        // there should be 90 tokens available
+        assertThat(asyncTokenBucket.getTokens()).isEqualTo(90);
+    }
+
+    @Test
+    void shouldAccuratelyCalculateTokensWhenTimeIsLaggingBehindInInconsistentUpdates() {
+        clockSource = requestSnapshot -> {
+          if (requestSnapshot) {
+              return manualClockSource.get();
+          } else {
+              // let the clock lag behind
+              return manualClockSource.get() - TimeUnit.SECONDS.toNanos(52);
+          }
+        };
+        incrementSeconds(1);
+        asyncTokenBucket =
+                AsyncTokenBucket.builder().resolutionNanos(TimeUnit.SECONDS.toNanos(51))
+                        .capacity(100).rate(10).initialTokens(100).clock(clockSource).build();
+        assertThat(asyncTokenBucket.getTokens()).isEqualTo(100);
+
+        // consume tokens without exceeding the rate
+        for (int i = 0; i < 10000; i++) {
+            asyncTokenBucket.consumeTokens(500);
+            incrementSeconds(i == 0 ? 40 : 50);
+        }
+
+        // let 9 seconds pass
+        incrementSeconds(9);
+
+        // there should be 90 tokens available
+        assertThat(asyncTokenBucket.getTokens()).isEqualTo(90);
+    }
+
+    @Test
+    void shouldHandleEventualConsistency() {
+        AtomicLong offset = new AtomicLong(0);
+        long resolutionNanos = TimeUnit.MILLISECONDS.toNanos(1);
+        DefaultMonotonicSnapshotClock monotonicSnapshotClock =
+                new DefaultMonotonicSnapshotClock(resolutionNanos,
+                        () -> offset.get() + manualClockSource.get());
+        long initialTokens = 500L;
+        asyncTokenBucket =
+                AsyncTokenBucket.builder()
+                        .consistentConsumedTokens(true)
+                        .resolutionNanos(resolutionNanos)
+                        .capacity(100000).rate(1000).initialTokens(initialTokens).clock(monotonicSnapshotClock).build();
+        for (int i = 0; i < 100000; i++) {
+            // increment the clock by 1ms, since rate is 1000 tokens/s, this should make 1 token available
+            incrementMillis(1);
+            // consume 1 token
+            asyncTokenBucket.consumeTokens(1);
+        }
+        assertThat(asyncTokenBucket.getTokens())
+                // since the rate is 1/ms and the test increments the clock by 1ms and consumes 1 token in each
+                // iteration, the tokens should be equal to the initial tokens
+                .isEqualTo(initialTokens);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/qos/DefaultMonotonicSnapshotClockTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.qos;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.data.Offset;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class DefaultMonotonicSnapshotClockTest {
+    @DataProvider
+    private static Object[] booleanValues() {
+        return new Object[]{ true, false };
+    }
+
+    @Test(dataProvider = "booleanValues")
+    void testClockHandlesTimeLeapsBackwards(boolean requestSnapshot) throws InterruptedException {
+        long snapshotIntervalMillis = 5;
+        AtomicLong clockValue = new AtomicLong(1);
+        @Cleanup
+        DefaultMonotonicSnapshotClock clock =
+                new DefaultMonotonicSnapshotClock(Duration.ofMillis(snapshotIntervalMillis).toNanos(),
+                        clockValue::get);
+
+
+        long previousTick = -1;
+        boolean leapDirection = true;
+        for (int i = 0; i < 10000; i++) {
+            clockValue.addAndGet(TimeUnit.MILLISECONDS.toNanos(1));
+            long tick = clock.getTickNanos(requestSnapshot);
+            //log.info("i = {}, tick = {}", i, tick);
+            if ((i + 1) % 5 == 0) {
+                leapDirection = !leapDirection;
+                //log.info("Time leap 5 minutes backwards");
+                clockValue.addAndGet(-Duration.ofMinutes(5).toNanos());
+            }
+            if (previousTick != -1) {
+                assertThat(tick)
+                        .describedAs("i = %d, tick = %d, previousTick = %d", i, tick, previousTick)
+                        .isGreaterThanOrEqualTo(previousTick)
+                        .isCloseTo(previousTick,
+                                // then snapshot is requested, the time difference between the two ticks is accurate
+                                // otherwise allow time difference at most 4 times the snapshot interval since the
+                                // clock is updated periodically by a background thread
+                                Offset.offset(TimeUnit.MILLISECONDS.toNanos(
+                                        requestSnapshot ? 1 : 4 * snapshotIntervalMillis)));
+            }
+            previousTick = tick;
+        }
+    }
+
+    @Test
+    void testRequestUpdate() throws InterruptedException {
+        @Cleanup
+        DefaultMonotonicSnapshotClock clock =
+                new DefaultMonotonicSnapshotClock(Duration.ofSeconds(5).toNanos(), System::nanoTime);
+        long tick1 = clock.getTickNanos(false);
+        long tick2 = clock.getTickNanos(true);
+        assertThat(tick2).isGreaterThan(tick1);
+    }
+
+    @Test
+    void testRequestingSnapshotAfterClosed() throws InterruptedException {
+        DefaultMonotonicSnapshotClock clock =
+                new DefaultMonotonicSnapshotClock(Duration.ofSeconds(5).toNanos(), System::nanoTime);
+        clock.close();
+        long tick1 = clock.getTickNanos(true);
+        Thread.sleep(10);
+        long tick2 = clock.getTickNanos(true);
+        assertThat(tick2).isGreaterThan(tick1);
+    }
+
+    @Test
+    void testConstructorValidation() {
+        assertThatThrownBy(() -> new DefaultMonotonicSnapshotClock(0, System::nanoTime))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("snapshotIntervalNanos must be at least 1 millisecond");
+        assertThatThrownBy(() -> new DefaultMonotonicSnapshotClock(-1, System::nanoTime))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("snapshotIntervalNanos must be at least 1 millisecond");
+        assertThatThrownBy(() -> new DefaultMonotonicSnapshotClock(TimeUnit.MILLISECONDS.toNanos(1), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("clockSource must not be null");
+    }
+
+    @Test
+    void testFailureHandlingInClockSource() {
+        @Cleanup
+        DefaultMonotonicSnapshotClock clock =
+                new DefaultMonotonicSnapshotClock(Duration.ofSeconds(5).toNanos(), () -> {
+                    throw new RuntimeException("Test clock failure");
+                });
+        // the exception should be propagated
+        assertThatThrownBy(() -> clock.getTickNanos(true))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Test clock failure");
+    }
+
+    @Test
+    void testLeapDetectionIndependently() {
+        AtomicLong clockValue = new AtomicLong(0);
+        AtomicLong tickValue = new AtomicLong(0);
+        long expectedTickValue = 0;
+        long snapshotIntervalNanos = TimeUnit.MILLISECONDS.toNanos(1);
+        DefaultMonotonicSnapshotClock.MonotonicLeapDetectingTickUpdater updater =
+                new DefaultMonotonicSnapshotClock.MonotonicLeapDetectingTickUpdater(clockValue::get, tickValue::set,
+                        snapshotIntervalNanos);
+
+        updater.update(true);
+
+        // advance the clock
+        clockValue.addAndGet(snapshotIntervalNanos);
+        expectedTickValue += snapshotIntervalNanos;
+        updater.update(true);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+
+        // simulate a leap backwards in time
+        clockValue.addAndGet(-10 * snapshotIntervalNanos);
+        expectedTickValue += snapshotIntervalNanos;
+        updater.update(true);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+
+        // advance the clock
+        clockValue.addAndGet(snapshotIntervalNanos);
+        expectedTickValue += snapshotIntervalNanos;
+        updater.update(true);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+
+        // simulate a leap backwards in time, without waiting a full snapshot interval
+        clockValue.addAndGet(-10 * snapshotIntervalNanos);
+        updater.update(false);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+
+        // advance the clock
+        clockValue.addAndGet(snapshotIntervalNanos);
+        expectedTickValue += snapshotIntervalNanos;
+        updater.update(true);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+
+        // simulate a small leap backwards in time which isn't detected, without waiting a full snapshot interval
+        clockValue.addAndGet(-1 * snapshotIntervalNanos);
+        updater.update(false);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+        // clock doesn't advance for one snapshot interval
+        clockValue.addAndGet(snapshotIntervalNanos);
+        updater.update(false);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+        // now the clock should advance again
+        clockValue.addAndGet(snapshotIntervalNanos);
+        expectedTickValue += snapshotIntervalNanos;
+        updater.update(false);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+
+        // simulate a leap forward
+        clockValue.addAndGet(10 * snapshotIntervalNanos);
+        // no special handling for leap forward
+        expectedTickValue += 10 * snapshotIntervalNanos;
+        updater.update(true);
+        assertThat(tickValue.get()).isEqualTo(expectedTickValue);
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/RGUsageMTAggrWaitForAllMsgsTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.qos.AsyncTokenBucket;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.BytesAndMessagesCount;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroup.ResourceGroupMonitoringClass;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupService.ResourceGroupUsageStatsType;
@@ -58,9 +59,10 @@ import org.testng.annotations.Test;
 @Slf4j
 @Test(groups = "flaky")
 public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
-    @BeforeClass
+    @BeforeClass(alwaysRun = true)
     @Override
     protected void setup() throws Exception {
+        AsyncTokenBucket.switchToConsistentTokensView();
         super.internalSetup();
         this.prepareForOps();
 
@@ -91,6 +93,7 @@ public class RGUsageMTAggrWaitForAllMsgsTest extends ProducerConsumerBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        AsyncTokenBucket.resetToDefaultEventualConsistentTokensView();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BatchMessageWithBatchIndexLevelTest.java
@@ -59,6 +59,7 @@ import org.apache.pulsar.common.util.collections.BitSetRecyclable;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -135,6 +136,67 @@ public class BatchMessageWithBatchIndexLevelTest extends BatchMessageTest {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 16);
         });
+    }
+
+    @DataProvider
+    public Object[][] enabledBatchSend() {
+        return new Object[][] {
+                {false},
+                {true}
+        };
+    }
+
+    @Test(dataProvider = "enabledBatchSend")
+    @SneakyThrows
+    public void testBatchMessageNAck(boolean enabledBatchSend) {
+        final String topicName = BrokerTestUtil.newUniqueName("persistent://prop/ns-abc/tp");
+        final String subscriptionName = "s1";
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subscriptionName)
+                .receiverQueueSize(21)
+                .subscriptionType(SubscriptionType.Shared)
+                .enableBatchIndexAcknowledgment(true)
+                .negativeAckRedeliveryDelay(100, TimeUnit.MILLISECONDS)
+                .subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .batchingMaxMessages(20)
+                .batchingMaxPublishDelay(1, TimeUnit.HOURS)
+                .enableBatching(enabledBatchSend)
+                .create();
+        final PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName).get();
+        final AbstractPersistentDispatcherMultipleConsumers dispatcher =
+                (AbstractPersistentDispatcherMultipleConsumers) topic.getSubscription(subscriptionName).getDispatcher();
+
+        // Send messages: 20 * 2.
+        for (int i = 0; i < 40; i++) {
+            byte[] message = ("batch-message-" + i).getBytes();
+            if (i == 19 || i == 39) {
+                producer.newMessage().value(message).send();
+            } else {
+                producer.newMessage().value(message).sendAsync();
+            }
+        }
+        Awaitility.await().untilAsserted(() -> {
+            if (enabledBatchSend) {
+                assertEquals(consumer.numMessagesInQueue(), 40);
+            } else {
+                assertEquals(consumer.numMessagesInQueue(), 21);
+            }
+        });
+
+        // Negative ack and verify result/
+        Message<byte[]> receive1 = consumer.receive();
+        consumer.pause();
+        consumer.negativeAcknowledge(receive1);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(consumer.numMessagesInQueue(), 20);
+            assertEquals(dispatcher.getConsumers().get(0).getUnackedMessages(), 20);
+        });
+
+        // cleanup.
+        producer.close();
+        consumer.close();
+        admin.topics().delete(topicName);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -636,7 +636,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(3, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
     }
 
     @Test
@@ -654,7 +654,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(2, 9));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
     }
 
     @Test
@@ -689,7 +689,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         assertNotNull(range);
         assertNotNull(range.getLeft());
         assertNotNull(range.getRight());
-        assertEquals(range.getLeft(), PositionFactory.create(3, 0));
+        assertEquals(range.getLeft(), PositionFactory.create(2, 0));
         assertEquals(range.getRight(), PositionFactory.create(3, 9));
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +74,9 @@ public class PublishRateLimiterTest {
         when(transportCnx.getBrokerService()).thenReturn(brokerService);
         EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
         when(brokerService.executor()).thenReturn(eventLoopGroup);
-        doReturn(null).when(eventLoopGroup).schedule(any(Runnable.class), anyLong(), any());
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoopGroup.next()).thenReturn(eventLoop);
+        doReturn(null).when(eventLoop).schedule(any(Runnable.class), anyLong(), any());
         incrementSeconds(1);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -27,8 +27,10 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +40,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -50,6 +58,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
@@ -61,6 +70,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.util.RelativeTimeUtil;
 import org.awaitility.Awaitility;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -72,6 +82,10 @@ public class SubscriptionSeekTest extends BrokerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+        conf.setManagedLedgerMinLedgerRolloverTimeMinutes(0);
+        conf.setManagedLedgerMaxEntriesPerLedger(10);
+        conf.setDefaultRetentionSizeInMB(100);
+        conf.setDefaultRetentionTimeInMinutes(100);
         super.baseSetup();
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
     }
@@ -487,6 +501,110 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         Awaitility.await().until(consumer::isConnected);
         consumer.seek(currentTimestamp - resetTimeInMillis);
         assertEquals(sub.getNumberOfEntriesInBacklog(false), 10);
+    }
+
+    @Test(timeOut = 30_000)
+    public void testSeekByTimestamp() throws Exception {
+        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestamp";
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
+
+        @Cleanup
+        Producer<String> producer =
+                pulsarClient.newProducer(Schema.STRING).topic(topicName).enableBatching(false).create();
+        for (int i = 0; i < 25; i++) {
+            producer.send(("message-" + i));
+            Thread.sleep(10);
+        }
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).get().get();
+
+        Map<Long, MessageId> timestampToMessageId = new HashMap<>();
+        @Cleanup
+        Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topicName).startMessageId(MessageId.earliest).create();
+        while (reader.hasMessageAvailable()) {
+           Message<String> message = reader.readNext();
+              timestampToMessageId.put(message.getPublishTime(), message.getMessageId());
+        }
+
+        Assert.assertEquals(timestampToMessageId.size(), 25);
+
+        PersistentSubscription subscription = topic.getSubscription("my-sub");
+        ManagedCursor cursor = subscription.getCursor();
+
+        @Cleanup
+        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName).subscriptionName("my-sub").subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        long[] timestamps = timestampToMessageId.keySet().stream().mapToLong(Long::longValue).toArray();
+        ArrayUtils.shuffle(timestamps);
+        for (long timestamp : timestamps) {
+            MessageIdImpl messageId = (MessageIdImpl) timestampToMessageId.get(timestamp);
+            consumer.seek(timestamp);
+            Position readPosition = cursor.getReadPosition();
+            Assert.assertEquals(readPosition.getLedgerId(), messageId.getLedgerId());
+            Assert.assertEquals(readPosition.getEntryId(), messageId.getEntryId());
+        }
+    }
+
+    @Test(timeOut = 30_000)
+    public void testSeekByTimestampWithLedgerTrim() throws Exception {
+        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestampWithLedgerTrim";
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
+
+        @Cleanup
+        Producer<String> producer =
+                pulsarClient.newProducer(Schema.STRING).topic(topicName).enableBatching(false).create();
+        for (int i = 0; i < 25; i++) {
+            producer.send(("message-" + i));
+            Thread.sleep(10);
+        }
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false).get().get();
+        ManagedLedger ledger = topic.getManagedLedger();
+        ManagedLedgerConfig config = ledger.getConfig();
+        config.setRetentionTime(0, TimeUnit.SECONDS);
+        config.setRetentionSizeInMB(0);
+
+        Map<Long, MessageId> timestampToMessageId = new HashMap<>();
+        @Cleanup
+        Reader<String> reader = pulsarClient.newReader(Schema.STRING).topic(topicName).startMessageId(MessageId.earliest).create();
+        while (reader.hasMessageAvailable()) {
+            Message<String> message = reader.readNext();
+            timestampToMessageId.put(message.getPublishTime(), message.getMessageId());
+        }
+
+        Assert.assertEquals(timestampToMessageId.size(), 25);
+
+        PersistentSubscription subscription = topic.getSubscription("my-sub");
+        ManagedCursor cursor = subscription.getCursor();
+
+        @Cleanup
+        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+                .topic(topicName).subscriptionName("my-sub").subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        long[] timestamps = timestampToMessageId.keySet().stream().mapToLong(Long::longValue).toArray();
+        ArrayUtils.shuffle(timestamps);
+        boolean enterLedgerTrimmedBranch = false;
+        for (long timestamp : timestamps) {
+            MessageIdImpl messageId = (MessageIdImpl) timestampToMessageId.get(timestamp);
+            consumer.seek(timestamp);
+            CompletableFuture<?> trimFuture = new CompletableFuture<>();
+            ledger.trimConsumedLedgersInBackground(trimFuture);
+            trimFuture.get();
+            Position readPosition = cursor.getReadPosition();
+            Map.Entry<Long, MLDataFormats.ManagedLedgerInfo.LedgerInfo> firstLedger = ledger.getLedgersInfo().firstEntry();
+            Assert.assertNotNull(firstLedger);
+            if (firstLedger.getKey() > messageId.getLedgerId()) {
+                Assert.assertEquals(readPosition.getLedgerId(), firstLedger.getKey());
+                Assert.assertEquals(readPosition.getEntryId(), 0);
+                enterLedgerTrimmedBranch = true;
+            } else {
+                Assert.assertEquals(readPosition.getLedgerId(), messageId.getLedgerId());
+                Assert.assertEquals(readPosition.getEntryId(), messageId.getEntryId());
+            }
+        }
+        // May have a chance to cause flaky test, because the result of `ArrayUtils.shuffle(timestamps);` is random.
+        Assert.assertTrue(enterLedgerTrimmedBranch);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/transaction/buffer/impl/TransactionPersistentTopicTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.transaction.buffer.impl;
+
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.pulsar.broker.BrokerTestUtil;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.TopicFactory;
+import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.transaction.buffer.AbortedTxnProcessor;
+import org.apache.pulsar.broker.transaction.buffer.TransactionBufferProvider;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "broker")
+public class TransactionPersistentTopicTest extends ProducerConsumerBase {
+
+    private static CountDownLatch topicInitSuccessSignal = new CountDownLatch(1);
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        // Intercept when the `topicFuture` is about to complete and wait until the topic close operation finishes.
+        conf.setTopicFactoryClassName(MyTopicFactory.class.getName());
+        conf.setTransactionCoordinatorEnabled(true);
+        conf.setBrokerDeduplicationEnabled(false);
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testNoOrphanClosedTopicIfTxnInternalFailed() {
+        String tpName = BrokerTestUtil.newUniqueName("persistent://public/default/tp2");
+
+        BrokerService brokerService = pulsar.getBrokerService();
+
+        // 1. Mock close topic when create transactionBuffer
+        TransactionBufferProvider mockTransactionBufferProvider = originTopic -> {
+            AbortedTxnProcessor abortedTxnProcessor = mock(AbortedTxnProcessor.class);
+            doAnswer(invocation -> {
+                topicInitSuccessSignal.await();
+                return CompletableFuture.failedFuture(new RuntimeException("Mock recovery failed"));
+            }).when(abortedTxnProcessor).recoverFromSnapshot();
+            when(abortedTxnProcessor.closeAsync()).thenReturn(CompletableFuture.completedFuture(null));
+            return new TopicTransactionBuffer(
+                    (PersistentTopic) originTopic, abortedTxnProcessor, AbortedTxnProcessor.SnapshotType.Single);
+        };
+        TransactionBufferProvider originalTransactionBufferProvider = pulsar.getTransactionBufferProvider();
+        pulsar.setTransactionBufferProvider(mockTransactionBufferProvider);
+
+        // 2. Trigger create topic and assert topic load success.
+        CompletableFuture<Optional<Topic>> firstLoad = brokerService.getTopic(tpName, true);
+        Awaitility.await().ignoreExceptions().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertTrue(firstLoad.isDone());
+                    assertFalse(firstLoad.isCompletedExceptionally());
+                });
+
+        // 3. Assert topic removed from cache
+        Awaitility.await().ignoreExceptions().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertFalse(brokerService.getTopics().containsKey(tpName));
+                });
+
+        // 4. Set txn provider to back
+        pulsar.setTransactionBufferProvider(originalTransactionBufferProvider);
+    }
+
+    public static class MyTopicFactory implements TopicFactory {
+        @Override
+        public <T extends Topic> T create(String topic, ManagedLedger ledger, BrokerService brokerService,
+                                          Class<T> topicClazz) {
+            try {
+                if (topicClazz == NonPersistentTopic.class) {
+                    return (T) new NonPersistentTopic(topic, brokerService);
+                } else {
+                    return (T) new MyPersistentTopic(topic, ledger, brokerService);
+                }
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            // No-op
+        }
+    }
+
+    public static class MyPersistentTopic extends PersistentTopic {
+
+        public MyPersistentTopic(String topic, ManagedLedger ledger, BrokerService brokerService) {
+            super(topic, ledger, brokerService);
+        }
+
+        @SneakyThrows
+        @Override
+        public CompletableFuture<Void> checkDeduplicationStatus() {
+            topicInitSuccessSignal.countDown();
+            // Sleep 1s pending txn buffer recover failed and close topic
+            Thread.sleep(1000);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AbstractMessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AbstractMessageDispatchThrottlingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.qos.AsyncTokenBucket;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+
+public abstract class AbstractMessageDispatchThrottlingTest extends ProducerConsumerBase {
+    public static <T> T[] merge(T[] first, T[] last) {
+        int totalLength = first.length + last.length;
+        T[] result = Arrays.copyOf(first, totalLength);
+        int offset = first.length;
+        System.arraycopy(last, 0, result, offset, first.length);
+        return result;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    @Override
+    protected void setup() throws Exception {
+        AsyncTokenBucket.switchToConsistentTokensView();
+        this.conf.setClusterName("test");
+        internalSetup();
+        producerBaseSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        internalCleanup();
+        AsyncTokenBucket.resetToDefaultEventualConsistentTokensView();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    protected void reset() throws Exception {
+        pulsar.getConfiguration().setForceDeleteTenantAllowed(true);
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
+
+        for (String tenant : admin.tenants().getTenants()) {
+            for (String namespace : admin.namespaces().getNamespaces(tenant)) {
+                admin.namespaces().deleteNamespace(namespace, true);
+            }
+            admin.tenants().deleteTenant(tenant, true);
+        }
+
+        for (String cluster : admin.clusters().getClusters()) {
+            admin.clusters().deleteCluster(cluster);
+        }
+
+        pulsar.getConfiguration().setForceDeleteTenantAllowed(false);
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(false);
+
+        producerBaseSetup();
+    }
+
+    @DataProvider(name = "subscriptions")
+    public Object[][] subscriptionsProvider() {
+        return new Object[][]{new Object[]{SubscriptionType.Shared}, {SubscriptionType.Exclusive}};
+    }
+
+    @DataProvider(name = "dispatchRateType")
+    public Object[][] dispatchRateProvider() {
+        return new Object[][]{{DispatchRateType.messageRate}, {DispatchRateType.byteRate}};
+    }
+
+    @DataProvider(name = "subscriptionAndDispatchRateType")
+    public Object[][] subDisTypeProvider() {
+        List<Object[]> mergeList = new LinkedList<>();
+        for (Object[] sub : subscriptionsProvider()) {
+            for (Object[] dispatch : dispatchRateProvider()) {
+                mergeList.add(AbstractMessageDispatchThrottlingTest.merge(sub, dispatch));
+            }
+        }
+        return mergeList.toArray(new Object[0][0]);
+    }
+
+    protected void deactiveCursors(ManagedLedgerImpl ledger) throws Exception {
+        Field statsUpdaterField = BrokerService.class.getDeclaredField("statsUpdater");
+        statsUpdaterField.setAccessible(true);
+        ScheduledExecutorService statsUpdater = (ScheduledExecutorService) statsUpdaterField
+                .get(pulsar.getBrokerService());
+        statsUpdater.shutdownNow();
+        ledger.getCursors().forEach(cursor -> {
+            ledger.deactivateCursor(cursor);
+        });
+    }
+
+    enum DispatchRateType {
+        messageRate, byteRate;
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MessageDispatchThrottlingTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
@@ -27,15 +28,11 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
@@ -43,7 +40,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.cache.PendingReadsManager;
 import org.apache.bookkeeper.mledger.impl.cache.RangeEntryCacheImpl;
-import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -52,92 +49,16 @@ import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.PublishRate;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.impl.DispatchRateImpl;
-import org.apache.pulsar.broker.qos.AsyncTokenBucket;
+import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(groups = "flaky")
-public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
+@Test(groups = "broker-api")
+public class MessageDispatchThrottlingTest extends AbstractMessageDispatchThrottlingTest {
     private static final Logger log = LoggerFactory.getLogger(MessageDispatchThrottlingTest.class);
-
-    @BeforeClass
-    @Override
-    protected void setup() throws Exception {
-        AsyncTokenBucket.switchToConsistentTokensView();
-        this.conf.setClusterName("test");
-        super.internalSetup();
-        super.producerBaseSetup();
-    }
-
-    @AfterClass(alwaysRun = true)
-    @Override
-    protected void cleanup() throws Exception {
-        super.internalCleanup();
-        AsyncTokenBucket.resetToDefaultEventualConsistentTokensView();
-    }
-
-    @AfterMethod(alwaysRun = true)
-    protected void reset() throws Exception {
-        pulsar.getConfiguration().setForceDeleteTenantAllowed(true);
-        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
-
-        for (String tenant : admin.tenants().getTenants()) {
-            for (String namespace : admin.namespaces().getNamespaces(tenant)) {
-                admin.namespaces().deleteNamespace(namespace, true);
-            }
-            admin.tenants().deleteTenant(tenant, true);
-        }
-
-        for (String cluster : admin.clusters().getClusters()) {
-            admin.clusters().deleteCluster(cluster);
-        }
-
-        pulsar.getConfiguration().setForceDeleteTenantAllowed(false);
-        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(false);
-
-        super.producerBaseSetup();
-    }
-
-
-    @DataProvider(name = "subscriptions")
-    public Object[][] subscriptionsProvider() {
-        return new Object[][] { new Object[] { SubscriptionType.Shared }, { SubscriptionType.Exclusive } };
-    }
-
-    @DataProvider(name = "dispatchRateType")
-    public Object[][] dispatchRateProvider() {
-        return new Object[][] { { DispatchRateType.messageRate }, { DispatchRateType.byteRate } };
-    }
-
-    @DataProvider(name = "subscriptionAndDispatchRateType")
-    public Object[][] subDisTypeProvider() {
-        List<Object[]> mergeList = new LinkedList<>();
-        for (Object[] sub : subscriptionsProvider()) {
-            for (Object[] dispatch : dispatchRateProvider()) {
-                mergeList.add(merge(sub, dispatch));
-            }
-        }
-        return mergeList.toArray(new Object[0][0]);
-    }
-
-    public static <T> T[] merge(T[] first, T[] last) {
-        int totalLength = first.length + last.length;
-        T[] result = Arrays.copyOf(first, totalLength);
-        int offset = first.length;
-        System.arraycopy(last, 0, result, offset, first.length);
-        return result;
-    }
-
-    enum DispatchRateType {
-        messageRate, byteRate;
-    }
 
     /**
      * verifies: message-rate change gets reflected immediately into topic at runtime
@@ -150,7 +71,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
 
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
@@ -220,7 +141,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testSystemTopicDeliveryNonBlock() throws Exception {
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         final String topicName = "persistent://" + namespace + "/" + UUID.randomUUID().toString().replaceAll("-", "");
         admin.topics().createNonPartitionedTopic(topicName);
@@ -264,7 +185,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
             DispatchRateType dispatchRateType) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         final int messageRate = 100;
@@ -332,7 +253,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClusterMsgByteRateLimitingClusterConfig() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
         final int messageRate = 5;
         final long byteRate = 1024 * 1024;// 1MB rate enough to let all msg to be delivered
@@ -407,7 +328,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
             throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingAll";
 
         final int messageRate = 10;
@@ -475,7 +396,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(true);
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingAll";
         final String subscriptionName = "my-subscriber-name";
 
@@ -528,8 +449,9 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testRateLimitingMultipleConsumers() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingMultipleConsumers";
+        conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(true);
 
         final int messageRate = 5;
         DispatchRate dispatchRate = DispatchRate.builder()
@@ -540,7 +462,8 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         admin.namespaces().setDispatchRate(namespace, dispatchRate);
         // create producer and topic
-        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        @Cleanup
+        Producer<byte[]> producer = pulsarClient.newProducer().enableBatching(false).topic(topicName).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
 
         Awaitility.await()
@@ -566,10 +489,15 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
                         throw new RuntimeException(e);
                     }
                 });
+        @Cleanup
         Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer3 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer4 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer5 = consumerBuilder.subscribe();
 
         // deactive cursors
@@ -585,15 +513,10 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         Thread.sleep(1000);
 
         // rate limiter should have limited messages with at least 10% accuracy (or 2 messages if messageRate is low)
-        Assert.assertEquals(totalReceived.get(), messageRate, Math.max(messageRate / 10, 2));
+        assertThat(totalReceived.get()).isCloseTo(messageRate, Offset.offset(Math.max(messageRate / 10, 2)));
 
-        consumer1.close();
-        consumer2.close();
-        consumer3.close();
-        consumer4.close();
-        consumer5.close();
-        producer.close();
         log.info("-- Exiting {} test --", methodName);
+        conf.setDispatchThrottlingOnNonBacklogConsumerEnabled(false);
     }
 
     @Test
@@ -602,7 +525,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
 
         conf.setDispatchThrottlingOnBatchMessageEnabled(true);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingMultipleConsumers";
 
         final int messageRate = 5;
@@ -614,6 +537,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         final int messagesPerBatch = 100;
         final int numProducedMessages = messageRate * messagesPerBatch;
         // create producer and topic
+        @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(true)
                 .batchingMaxPublishDelay(1, TimeUnit.SECONDS).batchingMaxMessages(messagesPerBatch).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
@@ -634,10 +558,15 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
                     log.debug("Received message [{}] in the listener", receivedMessage);
                     totalReceived.incrementAndGet();
                 });
+        @Cleanup
         Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer3 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer4 = consumerBuilder.subscribe();
+        @Cleanup
         Consumer<byte[]> consumer5 = consumerBuilder.subscribe();
 
         // deactive cursors
@@ -657,12 +586,6 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         // consumer should not have received all published message due to message-rate throttling
         Assert.assertEquals(totalReceived.get(), numProducedMessages);
 
-        consumer1.close();
-        consumer2.close();
-        consumer3.close();
-        consumer4.close();
-        consumer5.close();
-        producer.close();
         log.info("-- Exiting {} test --", methodName);
     }
 
@@ -670,7 +593,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClusterRateLimitingConfiguration(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
         final int messageRate = 5;
 
@@ -688,12 +611,14 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
 
         admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
         // create producer and topic
+        @Cleanup
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getOrCreateTopic(topicName).get();
         int numMessages = 500;
 
         final AtomicInteger totalReceived = new AtomicInteger(0);
 
+        @Cleanup
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name")
                 .subscriptionType(subscription).messageListener((c1, msg) -> {
                     Assert.assertNotNull(msg, "Message cannot be null");
@@ -716,8 +641,6 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         // consumer should not have received all published message due to message-rate throttling
         Assert.assertNotEquals(totalReceived.get(), numMessages);
 
-        consumer.close();
-        producer.close();
         admin.brokers().updateDynamicConfiguration("dispatchThrottlingRatePerTopicInMsg",
                 Integer.toString(initValue));
         log.info("-- Exiting {} test --", methodName);
@@ -733,7 +656,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testMessageByteRateThrottlingCombined(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingAll";
 
         final int messageRate = 5; // 5 msgs per second
@@ -803,7 +726,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testGlobalNamespaceThrottling() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         final int messageRate = 5;
@@ -869,7 +792,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testNonBacklogConsumerWithThrottlingEnabled(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/throttlingBlock";
 
         final int messageRate = 10;
@@ -948,7 +871,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClusterPolicyOverrideConfiguration() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName1 = "persistent://" + namespace + "/throttlingOverride1";
         final String topicName2 = "persistent://" + namespace + "/throttlingOverride2";
         final int clusterMessageRate = 100;
@@ -1018,7 +941,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testClosingRateLimiter(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/throttling_ns");
         final String topicName = "persistent://" + namespace + "/closingRateLimiter" + subscription.name();
         final String subName = "mySubscription" + subscription.name();
 
@@ -1066,7 +989,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     @SuppressWarnings("deprecation")
     @Test
     public void testDispatchRateCompatibility2() throws Exception {
-        final String namespace = "my-property/dispatch-rate-compatibility";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/dispatch-rate-compatibility");
         final String topicName = "persistent://" + namespace + "/t1";
         final String cluster = "test";
         admin.namespaces().createNamespace(namespace, Sets.newHashSet(cluster));
@@ -1112,17 +1035,6 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
         topic.close().get();
     }
 
-    protected void deactiveCursors(ManagedLedgerImpl ledger) throws Exception {
-        Field statsUpdaterField = BrokerService.class.getDeclaredField("statsUpdater");
-        statsUpdaterField.setAccessible(true);
-        ScheduledExecutorService statsUpdater = (ScheduledExecutorService) statsUpdaterField
-                .get(pulsar.getBrokerService());
-        statsUpdater.shutdownNow();
-        ledger.getCursors().forEach(cursor -> {
-            ledger.deactivateCursor(cursor);
-        });
-    }
-
     /**
      * It verifies that relative throttling at least dispatch messages as publish-rate.
      *
@@ -1133,7 +1045,7 @@ public class MessageDispatchThrottlingTest extends ProducerConsumerBase {
     public void testRelativeMessageRateLimitingThrottling(SubscriptionType subscription) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        final String namespace = "my-property/relative_throttling_ns";
+        final String namespace = BrokerTestUtil.newUniqueName("my-property/relative_throttling_ns");
         final String topicName = "persistent://" + namespace + "/relative-throttle" + subscription;
 
         final int messageRate = 1;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessagePublishThrottlingTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test
+@Test(groups = "broker-api")
 public class MessagePublishThrottlingTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(MessagePublishThrottlingTest.class);
 

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -63,6 +63,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
     private transient KeyRefresher keyRefresher = null;
     private transient ZTSClient ztsClient = null;
     private String ztsUrl = null;
+    private String ztsProxyUrl = null;
     private String tenantDomain;
     private String tenantService;
     private String providerDomain;
@@ -193,6 +194,9 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         if (isNotBlank(authParams.get("ztsUrl"))) {
             this.ztsUrl = authParams.get("ztsUrl");
         }
+        if (isNotBlank(authParams.get("ztsProxyUrl"))) {
+            this.ztsProxyUrl = authParams.get("ztsProxyUrl");
+        }
     }
 
     @Override
@@ -219,11 +223,11 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
                 }
                 final SSLContext sslContext = Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(),
                         keyRefresher.getTrustManagerProxy());
-                ztsClient = new ZTSClient(ztsUrl, sslContext);
+                ztsClient = new ZTSClient(ztsUrl, ztsProxyUrl, sslContext);
             } else {
                 ServiceIdentityProvider siaProvider = new SimpleServiceIdentityProvider(tenantDomain, tenantService,
                         privateKey, keyId);
-                ztsClient = new ZTSClient(ztsUrl, tenantDomain, tenantService, siaProvider);
+                ztsClient = new ZTSClient(ztsUrl, ztsProxyUrl, tenantDomain, tenantService, siaProvider);
             }
             ztsClient.setPrefetchAutoEnable(this.autoPrefetchEnabled);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -2831,27 +2831,18 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     private int removeExpiredMessagesFromQueue(Set<MessageId> messageIds) {
         int messagesFromQueue = 0;
-        Message<T> peek = incomingMessages.peek();
-        if (peek != null) {
-            MessageId messageId = NegativeAcksTracker.discardBatchAndPartitionIndex(peek.getMessageId());
-            if (!messageIds.contains(messageId)) {
-                // first message is not expired, then no message is expired in queue.
-                return 0;
+        Message<T> message;
+        while (true) {
+            message = incomingMessages.pollIf(msg -> {
+                MessageId idPolled = NegativeAcksTracker.discardBatchAndPartitionIndex(msg.getMessageId());
+                return messageIds.contains(idPolled);
+            });
+            if (message == null) {
+                break;
             }
-
-            // try not to remove elements that are added while we remove
-            Message<T> message = incomingMessages.poll();
-            while (message != null) {
-                decreaseIncomingMessageSize(message);
-                messagesFromQueue++;
-                MessageId id = NegativeAcksTracker.discardBatchAndPartitionIndex(message.getMessageId());
-                if (!messageIds.contains(id)) {
-                    messageIds.add(id);
-                    break;
-                }
-                message.release();
-                message = incomingMessages.poll();
-            }
+            decreaseIncomingMessageSize(message);
+            messagesFromQueue++;
+            message.release();
         }
         return messagesFromQueue;
     }

--- a/pulsar-io/common/pom.xml
+++ b/pulsar-io/common/pom.xml
@@ -49,6 +49,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-io/core/pom.xml
+++ b/pulsar-io/core/pom.xml
@@ -41,6 +41,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${spotbugs-maven-plugin.version}</version>

--- a/pulsar-io/pom.xml
+++ b/pulsar-io/pom.xml
@@ -150,6 +150,13 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>${skipDeployConnector}</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>
           <execution>

--- a/tiered-storage/pom.xml
+++ b/tiered-storage/pom.xml
@@ -39,4 +39,16 @@
     <module>jcloud</module>
     <module>file-system</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION

### Motivation

- Because all changes to queuedHandles are in the lock, there is no need to use thread-safe collections

### Modifications

- Replace SpscArrayQueue with ArrayDeque.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
